### PR TITLE
Clean up some docs

### DIFF
--- a/src/v0.10/guide/resources.md
+++ b/src/v0.10/guide/resources.md
@@ -225,19 +225,19 @@ Here's an example of sorting books by the author name:
 
 ```ruby
 class Book < ActiveRecord::Base
-    belongs_to :author
+  belongs_to :author
 end
 
 class Author < ActiveRecord::Base
-    has_many :books
+  has_many :books
 end
 
 class BookResource < JSONAPI::Resource
   attributes :title, :body
 
   def self.sortable_fields(context)
-    super(context) << :"author.name"
-   end
+    super + [:"author.name"]
+  end
 end
 ```
 The request will look something like:

--- a/src/v0.8/guide/resources.md
+++ b/src/v0.8/guide/resources.md
@@ -225,19 +225,19 @@ Here's an example of sorting books by the author name:
 
 ```ruby
 class Book < ActiveRecord::Base
-    belongs_to :author
+  belongs_to :author
 end
 
 class Author < ActiveRecord::Base
-    has_many :books
+  has_many :books
 end
 
 class BookResource < JSONAPI::Resource
   attributes :title, :body
 
   def self.sortable_fields(context)
-    super(context) << :"author.name"
-   end
+    super + [:"author.name"]
+  end
 end
 ```
 The request will look something like:

--- a/src/v0.9/guide/resources.md
+++ b/src/v0.9/guide/resources.md
@@ -225,19 +225,19 @@ Here's an example of sorting books by the author name:
 
 ```ruby
 class Book < ActiveRecord::Base
-    belongs_to :author
+  belongs_to :author
 end
 
 class Author < ActiveRecord::Base
-    has_many :books
+  has_many :books
 end
 
 class BookResource < JSONAPI::Resource
   attributes :title, :body
 
   def self.sortable_fields(context)
-    super(context) << :"author.name"
-   end
+    super + [:"author.name"]
+  end
 end
 ```
 The request will look something like:


### PR DESCRIPTION
clean up relationship sort example

1. arg-less super auto-forwards args to super
2. Use array arithmetic instead of mutable-y
   << push operator (most of the other examples
   on the site use array arithmetic, e.g.
   updatable_fields)