### PR TITLE
change triple backticks to single backtick

### DIFF
--- a/src/v0.10/guide/controllers.md
+++ b/src/v0.10/guide/controllers.md
@@ -206,7 +206,7 @@ end
 
 #### Handling Exceptions
 
-By default, all exceptions raised downstream from a resource controller will be caught, logged, and a ```500 Internal Server Error``` will be rendered. Exceptions can be whitelisted in the config to pass through the handler and be caught manually, or you can pass a callback from a resource controller to insert logic into the rescue block without interrupting the control flow. This can be particularly useful for additional logging or monitoring without the added work of rendering responses.
+By default, all exceptions raised downstream from a resource controller will be caught, logged, and a `500 Internal Server Error` will be rendered. Exceptions can be whitelisted in the config to pass through the handler and be caught manually, or you can pass a callback from a resource controller to insert logic into the rescue block without interrupting the control flow. This can be particularly useful for additional logging or monitoring without the added work of rendering responses.
 
 Pass a block, refer to controller class methods, or both. Note that methods must be defined as class methods on a controller and accept one parameter, which is passed the exception object that was rescued.
 


### PR DESCRIPTION
Hello wonderful jsonapi-resources folks,

I was reading through documentation about controllers and noticed a slight issue with how it was rendered on the website.  In the part discussing `Handling Exceptions`, there was a triple backticks surrounding `500 Internal Server Error`  which causes some formatting issues in the documentation leaving out the number 500 and also displaying documentation text inside the code block (as seen in the screenshot below).  I went ahead and changed this to a single backtick.  

![screen shot 2017-05-24 at 12 12 34 pm](https://cloud.githubusercontent.com/assets/7807203/26413678/b8593e66-407a-11e7-8bf9-010433282ca4.png)

Thanks and hope you have a great day!