### PR TITLE
Update controllers.md

### DIFF
--- a/src/v0.9/guide/controllers.md
+++ b/src/v0.9/guide/controllers.md
@@ -206,7 +206,7 @@ end
 
 #### Handling Exceptions
 
-By default, all exceptions raised downstream from a resource controller will be caught, logged, and a ```500 Internal Server Error``` will be rendered. Exceptions can be whitelisted in the config to pass through the handler and be caught manually, or you can pass a callback from a resource controller to insert logic into the rescue block without interrupting the control flow. This can be particularly useful for additional logging or monitoring without the added work of rendering responses.
+By default, all exceptions raised downstream from a resource controller will be caught, logged, and a `500 Internal Server Error` will be rendered. Exceptions can be whitelisted in the config to pass through the handler and be caught manually, or you can pass a callback from a resource controller to insert logic into the rescue block without interrupting the control flow. This can be particularly useful for additional logging or monitoring without the added work of rendering responses.
 
 Pass a block, refer to controller class methods, or both. Note that methods must be defined as class methods on a controller and accept one parameter, which is passed the exception object that was rescued.
 


### PR DESCRIPTION
use inline rather than block code syntax; was causing problems on the http://jsonapi-resources.com/ docs

Before the change:

<img width="642" alt="screen shot 2017-10-29 at 19 41 09" src="https://user-images.githubusercontent.com/26158/32147546-34525eb6-bce1-11e7-9643-87d6df54d2ae.png">

After:
I've not checked the rendered html as not sure how you are doing that, but the github preview looks ok.