### PR TITLE
Improve documentation regarding custom sorting

### DIFF
--- a/src/v0.9/guide/resources.md
+++ b/src/v0.9/guide/resources.md
@@ -750,6 +750,41 @@ class AuthorResource < JSONAPI::Resource
 end
 ```
 
+## Custom Sorting
+
+You can override the `apply_sort` method to gain control over how the sorting is done. This may be useful in case you'd like to base the sorting on variables in your context.
+
+Example:
+
+```ruby
+def self.apply_sort(records, order_options, context = {})
+  if order_options.has_key?('trending')
+    records = records.order_by_trending_scope
+    order_options.delete('trending')
+  end
+
+  super(records, order_options, context)
+end
+```
+
+You can also sort record sets in-memory instead of via Active Record.
+
+Example:
+
+```ruby
+def self.apply_sort(records, order_options, context = {})
+  if order_options.has_key?('trending')
+    records = records.to_a.sort_by { |r| r.considered_trending?(context[:some_query_arg]) }
+    records.reverse! if order_options['trending'] == :desc
+
+    order_options.delete('trending')
+  end
+
+  super(records, order_options, context)
+end
+```
+
+
 ## Pagination
 
 Pagination is performed using a `paginator`, which is a class responsible for parsing the `page` request parameters and applying the pagination logic to the results.


### PR DESCRIPTION
Hi all. We are in the middle of an API implementation via jsonapi-resources, and really liking the gem! Thought I'd give back to the documentation a bit as we work things out that weren't clear up front.

- Break off Custom Sorting as its own section
- Correct example. `Hash#- and Hash#has?` aren't methods.
- Add example for in-memory sorting. 