### PR TITLE
Fix typos in routing guides

### DIFF
--- a/src/v0.10/guide/routing.md
+++ b/src/v0.10/guide/routing.md
@@ -49,7 +49,7 @@ Like `resources`, you may specify `only:` or `except:`, like `jsonapi_resources 
 
 ### `jsonapi_resource`
 
-Like `jsonapi_resources`, but for resources you lookup without an id. Resources used with this route should be marked as `singleton`. See the [Singlelton Resources](resources.html#Singleton-Resources) section for more details.
+Like `jsonapi_resources`, but for resources you lookup without an id. Resources used with this route should be marked as `singleton`. See the [Singleton Resources](resources.html#Singleton-Resources) section for more details.
 
 ## Nested Routes
 

--- a/src/v0.9/guide/routing.md
+++ b/src/v0.9/guide/routing.md
@@ -47,7 +47,7 @@ contact_relationships_phone_numbers GET       /contacts/:contact_id/relationship
 
 ### `jsonapi_resource`
 
-Like `jsonapi_resources`, but for resources you lookup without an id. Resources used with this route should be marked as `singleton`. See the [Singlelton Resources](resources.html#Singleton-Resources) section for more details.
+Like `jsonapi_resources`, but for resources you lookup without an id. Resources used with this route should be marked as `singleton`. See the [Singleton Resources](resources.html#Singleton-Resources) section for more details.
 
 ## Nested Routes
 


### PR DESCRIPTION
`Singlelton` -> `Singleton`